### PR TITLE
Handle partial trailing message

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1246,8 +1246,11 @@ impl FromByte for MessageSet {
         let l = msgs.len() as u64;
         let mut buf = Cursor::new(msgs);
         while l > buf.position() {
-            let mi = try!(MessageSetInner::decode_new(&mut buf));
-            self.message.push(mi);
+            match MessageSetInner::decode_new(&mut buf) {
+                Ok(val) => self.message.push(val),
+                Err(Error::UnexpectedEOF) => (),
+                Err(err) => return Err(err)
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
From https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-FetchAPI:
"As an optimization the server is allowed to return a partial message at the end of the message set. Clients should handle this case."

This appears to fix the issue in practice. This is my first Rust pull request, so if something's weird about the syntax it's because I have no clue what I'm doing, not a secret idiom or anything. :)