### PR TITLE
Avoid uncessary internal cloning (use-case sending-messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ kafka = "*"
 extern crate kafka;
 use kafka::client::KafkaClient;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
     // OR
-    // client.load_metadata(&vec!("my-topic".to_string())); // Loads metadata for vector of topics
+    // client.load_metadata(&vec!("my-topic".to_owned())); // Loads metadata for vector of topics
  }
 ```
 ##### Fetch Offsets:
@@ -40,9 +40,9 @@ fn main() {
 extern crate kafka;
 use kafka::client::KafkaClient;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
-    let offsets = client.fetch_topic_offset(&"my-topic".to_string());
+    let offsets = client.fetch_topic_offset(&"my-topic".to_owned());
 }
 ```
 
@@ -52,7 +52,7 @@ fn main() {
 extern crate kafka;
 use kafka::client::KafkaClient;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
     let topics = client.topic_partitions.keys().cloned().collect();
     let offsets = client.fetch_offsets(topics);
@@ -66,14 +66,14 @@ fn main() {
 extern crate kafka;
 use kafka::client::KafkaClient;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
     client.send_message(
         1,                              // Required Acks
         0,                              // Timeout
-        &"my-topic".to_string(),        // Topic
+        &"my-topic".to_owned(),        // Topic
         0,                              // Partition
-        &"b".to_string().into_bytes()   // Message
+        &"b".to_owned().into_bytes()   // Message
     )
 }
 ```
@@ -85,12 +85,12 @@ extern crate kafka;
 use kafka::client::KafkaClient;
 use kafka::utils;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
-    let m1 = "a".to_string().into_bytes();
-    let m2 = "b".to_string().into_bytes();
-    let req = vec!(utils::ProduceMessage{topic: "my-topic".to_string(), message: m1},
-                    utils::ProduceMessage{topic: "my-topic-2".to_string(), message: m2});
+    let m1 = "a".to_owned().into_bytes();
+    let m2 = "b".to_owned().into_bytes();
+    let req = vec!(utils::ProduceMessage{topic: "my-topic".to_owned(), message: m1},
+                    utils::ProduceMessage{topic: "my-topic-2".to_owned(), message: m2});
     client.send_messages(1, 100, req);  // required acks, timeout, messages
 }
 ```
@@ -103,10 +103,10 @@ fn main() {
 extern crate kafka;
 use kafka::client::KafkaClient;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
     // Topic, Partition, Offset
-    let msgs = client.fetch_messages(&"my-topic".to_string(), 0, 0);
+    let msgs = client.fetch_messages(&"my-topic".to_owned(), 0, 0);
 }
 ```
 
@@ -117,15 +117,15 @@ extern crate kafka;
 use kafka::client::KafkaClient;
 use kafka::utils;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
     let msgs = client.fetch_messages_multi(vec!(utils::TopicPartitionOffset{
-                                                    topic: "my-topic".to_string(),
+                                                    topic: "my-topic".to_owned(),
                                                     partition: 0,
                                                     offset: 0
                                                     },
                                                 utils::TopicPartitionOffset{
-                                                    topic: "my-topic-2".to_string(),
+                                                    topic: "my-topic-2".to_owned(),
                                                     partition: 0,
                                                     offset: 0
                                                 })));
@@ -140,10 +140,10 @@ fn main() {
 extern crate kafka;
 use kafka::client::KafkaClient;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
     // Group, Topic, Partition, Offset
-    let resp = client.commit_offset("my-group".to_string(), "my-topic".to_string(), 0, 100);
+    let resp = client.commit_offset("my-group".to_owned(), "my-topic".to_owned(), 0, 100);
 }
 ```
 
@@ -154,15 +154,15 @@ extern crate kafka;
 use kafka::client::KafkaClient;
 use kafka::utils;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
-    let msgs = client.commit_offsets("my-group".to_string(), vec!(utils::TopicPartitionOffset{
-                                                    topic: "my-topic".to_string(),
+    let msgs = client.commit_offsets("my-group".to_owned(), vec!(utils::TopicPartitionOffset{
+                                                    topic: "my-topic".to_owned(),
                                                     partition: 0,
                                                     offset: 0
                                                     },
                                                 utils::TopicPartitionOffset{
-                                                    topic: "my-topic-2".to_string(),
+                                                    topic: "my-topic-2".to_owned(),
                                                     partition: 0,
                                                     offset: 0
                                                 })));
@@ -177,10 +177,10 @@ fn main() {
 extern crate kafka;
 use kafka::client::KafkaClient;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
     // Group, Topic, Partition, Offset
-    let resp = client.fetch_group_offset("my-group".to_string());
+    let resp = client.fetch_group_offset("my-group".to_owned());
 }
 ```
 
@@ -191,9 +191,9 @@ extern crate kafka;
 use kafka::client::KafkaClient;
 use kafka::utils;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
-    let msgs = client.fetch_group_topic_offset("my-group".to_string(), "my-topic".to_string());
+    let msgs = client.fetch_group_topic_offset("my-group".to_owned(), "my-topic".to_owned());
 }
 ```
 
@@ -204,14 +204,14 @@ extern crate kafka;
 use kafka::client::KafkaClient;
 use kafka::utils;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
-    let msgs = client.fetch_group_topics_offset("my-group".to_string(), vec!(utils::TopicPartition{
-                                                    topic: "my-topic".to_string(),
+    let msgs = client.fetch_group_topics_offset("my-group".to_owned(), vec!(utils::TopicPartition{
+                                                    topic: "my-topic".to_owned(),
                                                     partition: 0
                                                     },
                                                 utils::TopicPartition{
-                                                    topic: "my-topic-2".to_string(),
+                                                    topic: "my-topic-2".to_owned(),
                                                     partition: 0
                                                 })));
 }
@@ -226,9 +226,9 @@ extern crate kafka;
 use kafka::client::KafkaClient;
 use kafka::utils;
 fn main() {
-    let mut client = KafkaClient::new(&vec!("localhost:9092".to_string()));
+    let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
-    let con = kafka::consumer::Consumer::new(client, "test-group".to_string(), "my-topic".to_string())
+    let con = kafka::consumer::Consumer::new(client, "test-group".to_owned(), "my-topic".to_owned())
              .partition(0);
     for msg in con {
         println!("{:?}", msg);

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,6 +12,7 @@ use codecs::{ToByte, FromByte};
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::io::Read;
+use std::rc::Rc;
 
 const CLIENTID: &'static str = "kafka-rust";
 const DEFAULT_TIMEOUT: i32 = 120; // seconds
@@ -33,7 +34,7 @@ const DEFAULT_TIMEOUT: i32 = 120; // seconds
 /// You will have to load metadata before making any other request.
 #[derive(Default, Debug)]
 pub struct KafkaClient {
-    clientid: String,
+    clientid: Rc<String>,
     timeout: i32,
     hosts: Vec<String>,
     correlation: i32,
@@ -53,7 +54,7 @@ impl KafkaClient {
     /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
     /// ```
     pub fn new(hosts: Vec<String>) -> KafkaClient {
-        KafkaClient { hosts: hosts, clientid: CLIENTID.to_string(),
+        KafkaClient { hosts: hosts, clientid: Rc::new(CLIENTID.to_owned()),
                       timeout: DEFAULT_TIMEOUT, ..KafkaClient::default()}
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,7 +27,7 @@ const DEFAULT_TIMEOUT: i32 = 120; // seconds
 /// # Examples
 ///
 /// ```no_run
-/// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+/// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
 /// let res = client.load_metadata_all();
 /// ```
 ///
@@ -52,7 +52,7 @@ impl KafkaClient {
     /// # Examples
     ///
     /// ```no_run
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// ```
     pub fn new(hosts: Vec<String>) -> KafkaClient {
         KafkaClient { hosts: hosts, clientid: Rc::new(CLIENTID.to_owned()),
@@ -67,7 +67,7 @@ impl KafkaClient {
         // TODO
         // Keeping this out here since get is causing ownership issues
         // Will refactor once I know better
-        self.conns.insert(host.to_string(),
+        self.conns.insert(host.to_owned(),
                           try!(KafkaConnection::new(host, self.timeout)));
         self.get_conn(host)
     }
@@ -83,7 +83,7 @@ impl KafkaClient {
     /// # Examples
     ///
     /// ```no_run
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
     /// ```
     ///
@@ -97,8 +97,8 @@ impl KafkaClient {
     /// # Examples
     ///
     /// ```no_run
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
-    /// let res = client.load_metadata(vec!("my-topic".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
+    /// let res = client.load_metadata(vec!("my-topic".to_owned()));
     /// ```
     ///
     /// returns `Result<(), error::Error>`
@@ -185,7 +185,7 @@ impl KafkaClient {
     /// # Examples
     ///
     /// ```no_run
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
     /// let topics = client.topic_partitions.keys().cloned().collect();
     /// let offsets = client.fetch_offsets(topics, -1);
@@ -230,9 +230,9 @@ impl KafkaClient {
     /// # Examples
     ///
     /// ```no_run
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
-    /// let offsets = client.fetch_topic_offset("my-topic".to_string(), -1);
+    /// let offsets = client.fetch_topic_offset("my-topic".to_owned(), -1);
     /// ```
     /// Returns a hashmap of (topic, PartitionOffset data).
     /// PartitionOffset will contain parition and offset info Or Error code as returned by Kafka.
@@ -253,15 +253,15 @@ impl KafkaClient {
     ///
     /// ```no_run
     /// use kafka::utils;
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
     /// let msgs = client.fetch_messages_multi(vec!(utils::TopicPartitionOffset{
-    ///                                                 topic: "my-topic".to_string(),
+    ///                                                 topic: "my-topic".to_owned(),
     ///                                                 partition: 0,
     ///                                                 offset: 0
     ///                                                 },
     ///                                             utils::TopicPartitionOffset{
-    ///                                                 topic: "my-topic-2".to_string(),
+    ///                                                 topic: "my-topic-2".to_owned(),
     ///                                                 partition: 0,
     ///                                                 offset: 0
     ///                                             }));
@@ -303,9 +303,9 @@ impl KafkaClient {
     /// # Examples
     ///
     /// ```no_run
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
-    /// let msgs = client.fetch_messages("my-topic".to_string(), 0, 0);
+    /// let msgs = client.fetch_messages("my-topic".to_owned(), 0, 0);
     /// ```
     pub fn fetch_messages(&mut self, topic: String, partition: i32, offset: i64) -> Result<Vec<utils::TopicMessage>>{
         self.fetch_messages_multi(vec!(utils::TopicPartitionOffset{
@@ -338,12 +338,12 @@ impl KafkaClient {
     ///
     /// ```no_run
     /// use kafka::utils;
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
-    /// let m1 = "a".to_string().into_bytes();
-    /// let m2 = "b".to_string().into_bytes();
-    /// let req = vec!(utils::ProduceMessage{topic: "my-topic".to_string(), message: m1},
-    ///                 utils::ProduceMessage{topic: "my-topic-2".to_string(), message: m2});
+    /// let m1 = "a".to_owned().into_bytes();
+    /// let m2 = "b".to_owned().into_bytes();
+    /// let req = vec!(utils::ProduceMessage{topic: "my-topic".to_owned(), message: m1},
+    ///                 utils::ProduceMessage{topic: "my-topic-2".to_owned(), message: m2});
     /// println!("{:?}", client.send_messages(1, 100, req));
     /// ```
     /// The return value will contain a vector of topic, partition, offset and error if any
@@ -405,9 +405,9 @@ impl KafkaClient {
     /// # Example
     ///
     /// ```no_run
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
-    /// let msgs = client.send_message(1, 100, "my-topic".to_string(), "msg".to_string().into_bytes());
+    /// let msgs = client.send_message(1, 100, "my-topic".to_owned(), "msg".to_owned().into_bytes());
     /// ```
     /// The return value will contain topic, partition, offset and error if any
     /// OR error:Error
@@ -432,11 +432,11 @@ impl KafkaClient {
     ///
     /// ```no_run
     /// use kafka::utils;
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
-    /// let resp = client.commit_offsets("my-group".to_string(), vec!(
-    ///                 utils::TopicPartitionOffset{topic: "my-topic".to_string(), partition: 0, offset: 100},
-    ///                 utils::TopicPartitionOffset{topic: "my-topic".to_string(), partition: 1, offset: 100}));
+    /// let resp = client.commit_offsets("my-group".to_owned(), vec!(
+    ///                 utils::TopicPartitionOffset{topic: "my-topic".to_owned(), partition: 0, offset: 100},
+    ///                 utils::TopicPartitionOffset{topic: "my-topic".to_owned(), partition: 1, offset: 100}));
     /// ```
     pub fn commit_offsets(&mut self, group: String, input: Vec<utils::TopicPartitionOffset>) -> Result<()>{
 
@@ -448,7 +448,7 @@ impl KafkaClient {
             self.get_broker(&tp.topic, &tp.partition).and_then(|broker| {
                 let entry = reqs.entry(broker.clone()).or_insert(
                             protocol::OffsetCommitRequest::new(group.clone(), correlation, self.clientid.clone()));
-                entry.add(tp.topic.clone(), tp.partition, tp.offset, "".to_string());
+                entry.add(tp.topic.clone(), tp.partition, tp.offset, "".to_owned());
                 Some(())
             });
         }
@@ -472,9 +472,9 @@ impl KafkaClient {
     ///
     /// ```no_run
     /// use kafka::utils;
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
-    /// let resp = client.commit_offset("my-group".to_string(), "my-topic".to_string(), 0, 100);
+    /// let resp = client.commit_offset("my-group".to_owned(), "my-topic".to_owned(), 0, 100);
     /// ```
     pub fn commit_offset(&mut self, group: String, topic: String,
                          partition: i32, offset: i64) -> Result<()>{
@@ -496,11 +496,11 @@ impl KafkaClient {
     ///
     /// ```no_run
     /// use kafka::utils;
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
-    /// let resp = client.fetch_group_topics_offset("my-group".to_string(), vec!(
-    ///                 utils::TopicPartition{topic: "my-topic".to_string(), partition: 0},
-    ///                 utils::TopicPartition{topic: "my-topic".to_string(), partition: 1}));
+    /// let resp = client.fetch_group_topics_offset("my-group".to_owned(), vec!(
+    ///                 utils::TopicPartition{topic: "my-topic".to_owned(), partition: 0},
+    ///                 utils::TopicPartition{topic: "my-topic".to_owned(), partition: 1}));
     /// ```
     pub fn fetch_group_topics_offset(&mut self, group: String, input: Vec<utils::TopicPartition>)
         -> Result<Vec<utils::TopicPartitionOffsetError>>{
@@ -543,9 +543,9 @@ impl KafkaClient {
     ///
     /// ```no_run
     /// use kafka::utils;
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
-    /// let resp = client.fetch_group_topic_offset("my-group".to_string(),"my-topic".to_string());
+    /// let resp = client.fetch_group_topic_offset("my-group".to_owned(),"my-topic".to_owned());
     /// ```
     pub fn fetch_group_topic_offset(&mut self, group: String, topic: String)
         -> Result<Vec<utils::TopicPartitionOffsetError>> {
@@ -570,9 +570,9 @@ impl KafkaClient {
     ///
     /// ```no_run
     /// use kafka::utils;
-    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+    /// let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
     /// let res = client.load_metadata_all();
-    /// let resp = client.fetch_group_offset("my-group".to_string());
+    /// let resp = client.fetch_group_offset("my-group".to_owned());
     /// ```
     pub fn fetch_group_offset(&mut self, group: String)
         -> Result<Vec<utils::TopicPartitionOffsetError>> {

--- a/src/codecs.rs
+++ b/src/codecs.rs
@@ -284,7 +284,7 @@ fn codec_i64() {
 fn codec_string() {
     use std::io::Cursor;
     let mut buf = vec!();
-    let orig = "test".to_string();
+    let orig = "test".to_owned();
 
     // Encode into buffer
     orig.encode(&mut buf).unwrap();

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -47,7 +47,6 @@ impl KafkaConnection {
 
     pub fn new(host: &str, timeout: i32) -> Result<KafkaConnection> {
         let stream = try!(TcpStream::connect(host));
-        Ok(KafkaConnection{host: host.to_string(), timeout: timeout, stream: stream})
-
+        Ok(KafkaConnection{host: host.to_owned(), timeout: timeout, stream: stream})
     }
 }

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -7,9 +7,9 @@
 //! # Example
 //!
 //! ```no_run
-//! let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_string()));
+//! let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
 //! let res = client.load_metadata_all();
-//! let con = kafka::consumer::Consumer::new(client, "test-group".to_string(), "my-topic".to_string())
+//! let con = kafka::consumer::Consumer::new(client, "test-group".to_owned(), "my-topic".to_owned())
 //!             .partition(0);
 //! for msg in con {
 //!     println!("{:?}", msg);

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,5 +1,6 @@
 use std::io::{Read, Write};
 use std::io::Cursor;
+use std::rc::Rc;
 
 use num::traits::FromPrimitive;
 
@@ -44,7 +45,7 @@ pub struct HeaderRequest {
     pub key: i16,
     pub version: i16,
     pub correlation: i32,
-    pub clientid: String
+    pub clientid: Rc<String>
 }
 
 #[derive(Default, Debug, Clone)]
@@ -337,7 +338,7 @@ pub struct Message {
 
 // Constructors for Requests
 impl MetadataRequest {
-    pub fn new(correlation: i32, clientid: String, topics: Vec<String>) -> MetadataRequest{
+    pub fn new(correlation: i32, clientid: Rc<String>, topics: Vec<String>) -> MetadataRequest{
         MetadataRequest{
             header: HeaderRequest{key: METADATA_KEY, correlation: correlation,
                                   clientid: clientid, version: VERSION},
@@ -347,7 +348,7 @@ impl MetadataRequest {
 }
 
 impl OffsetRequest {
-    pub fn new(correlation: i32, clientid: String) -> OffsetRequest{
+    pub fn new(correlation: i32, clientid: Rc<String>) -> OffsetRequest{
         OffsetRequest{
             header: HeaderRequest{key: OFFSET_KEY, correlation: correlation,
                                   clientid: clientid, version: VERSION},
@@ -425,7 +426,7 @@ impl PartitionOffsetResponse {
 
 impl ProduceRequest {
     pub fn new(required_acks: i16, timeout: i32,
-               correlation: i32, clientid: String) -> ProduceRequest{
+               correlation: i32, clientid: Rc<String>) -> ProduceRequest{
         ProduceRequest{
             header: HeaderRequest{key: PRODUCE_KEY, correlation: correlation,
                                   clientid: clientid, version: VERSION},
@@ -512,7 +513,7 @@ impl PartitionProduceResponse {
 
 impl FetchRequest {
 
-    pub fn new(correlation: i32, clientid: String) -> FetchRequest{
+    pub fn new(correlation: i32, clientid: Rc<String>) -> FetchRequest{
         FetchRequest{
             header: HeaderRequest{key: FETCH_KEY, correlation: correlation,
                                   clientid: clientid, version: VERSION},
@@ -594,7 +595,7 @@ impl PartitionFetchResponse {
 }
 
 impl OffsetCommitRequest {
-    pub fn new(group: String, correlation: i32, clientid: String) -> OffsetCommitRequest {
+    pub fn new(group: String, correlation: i32, clientid: Rc<String>) -> OffsetCommitRequest {
         OffsetCommitRequest{
             header: HeaderRequest{key: OFFSET_COMMIT_KEY, correlation: correlation,
                                   clientid: clientid, version: VERSION},
@@ -641,7 +642,7 @@ impl PartitionOffsetCommitRequest {
 }
 
 impl OffsetFetchRequest {
-    pub fn new(group: String, correlation: i32, clientid: String) -> OffsetFetchRequest {
+    pub fn new(group: String, correlation: i32, clientid: Rc<String>) -> OffsetFetchRequest {
         OffsetFetchRequest{
             header: HeaderRequest{key: OFFSET_FETCH_KEY, correlation: correlation,
                                   clientid: clientid, version: VERSION},


### PR DESCRIPTION
While looking at ways on how to go about #19 I spotted a huge number of clones internally in the library and got distracted by this. Initially I tried avoiding them by having the protocol structures use references, but got into a terrible fight with the borrow checker. Nevertheless, I was interested in how much overhead the allocations actually make up. So I set out to produce something that would provide me in some reasonable amount of work some figures (without changing the client API for the library); and here's the result:

the example/test program I used: https://github.com/xitep/monchan
my notes during the progress (the numbers are messages per second; higher-is-better):

```
#test invokation:
~/P/p/monchan (master)> for i in (seq 25); ./target/release/monchan --brokers 'localhost:9092' produce; end ^/tmp/i.2x

#after rc<clientid> change:
~/P/p/monchan (master)> awk 'END{print SUM/NR} {SUM=SUM+$8}' /tmp/i.25 
574775

#after changes in choose_partition:
~/P/p/monchan (master)> awk 'END{print SUM/NR} {SUM=SUM+$8}' /tmp/i.26
586702

#after changing topic_brokers to topic_brokers: HashMap<String, Rc<String>>:
~/P/p/monchan (master)> awk 'END{print SUM/NR} {SUM=SUM+$8}' /tmp/i.27
607494

#after avoiding unneccesary clones while sending message:
~/P/p/monchan (master)> awk 'END{print SUM/NR} {SUM=SUM+$8}' /tmp/i.31
656896
```

As you can see this is about a 14% improvement. The example program uses "no required_acks" (so the performance measuring is purely on the sending part of the library.) With waits for acks the difference is not so dramatic of course.

But even with the commits provided by this PR there's still a lot of (needless) allocations which could be avoided for the `send_messages` use-case (one particular that I couldn't get right on the fly was the allocations of keys for the lookup in `topic_borkers`), but this is outside my capacity at the moment. So I'm sending you these commits in the hope, you'll be able to use them somehow to improve your very nice library (I really like the mid-level client abstraction). Feel free to discard this PR, use individual commits from it, or maybe use it just as an inspiration. One serious allocation you would definitely want to take over is the avoidance of cloning the message payload itself (since that is a user provided amount of bytes) (see 32e9fbf). 

My dream would be that `KafkaClient` - once initialized - uses mostly references and thus avoids needless allocations. However, that would require some major changes to the code and changes to the public API.

I hope this can be helpful.