### PR TITLE
Avoid repeated hashmap lookups

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -43,9 +43,36 @@ pub struct KafkaClient {
     /// HashMap where `topic` is the key and list of `partitions` is the value
     pub topic_partitions: HashMap<String, Vec<i32>>,
 
+    // ~ an internal representation of `topic_partitions`;
+    // ~ TopicPartitions.partitions are kept in ascending order by `parition_id`
+    topic_partitions_internal: HashMap<String, TopicPartitions>,
+
     topic_brokers: HashMap<String, Rc<String>>,
-    topic_partition_curr: HashMap<String, i32>,
     compression: Compression
+}
+
+#[derive(Debug)]
+struct Partition {
+    partition_id: i32,
+    broker_host: Rc<String>,
+}
+
+impl Partition {
+    fn new(partition_id: i32, broker_host: Rc<String>) -> Partition {
+        Partition { partition_id: partition_id, broker_host: broker_host }
+    }
+}
+
+#[derive(Debug)]
+struct TopicPartitions {
+    curr_partition_idx: i32,
+    partitions: Vec<Partition>,
+}
+
+impl TopicPartitions {
+    fn new(partitions: Vec<Partition>) -> TopicPartitions {
+        TopicPartitions { curr_partition_idx: 0, partitions: partitions }
+    }
 }
 
 impl KafkaClient {
@@ -104,7 +131,7 @@ impl KafkaClient {
     /// ```
     ///
     /// returns `Result<(), error::Error>`
-    pub fn load_metadata(&mut self, topics: Vec<String>) -> Result<()>{
+    pub fn load_metadata(&mut self, topics: Vec<String>) -> Result<()> {
         let resp = try!(self.get_metadata(topics));
 
         let mut brokers: HashMap<i32, Rc<String>> = HashMap::new();
@@ -113,12 +140,14 @@ impl KafkaClient {
         }
 
         for topic in resp.topics {
-            self.topic_partitions.insert(topic.topic.clone(), vec!());
+            let mut known_partitions = Vec::with_capacity(topic.partitions.len());
+            let mut known_partitions_internal = Vec::with_capacity(topic.partitions.len());
 
             for partition in topic.partitions {
                 match brokers.get(&partition.leader) {
                     Some(broker) => {
-                        self.topic_partitions.get_mut(&topic.topic).unwrap().push(partition.id);
+                        known_partitions.push(partition.id);
+                        known_partitions_internal.push(Partition::new(partition.id, broker.clone()));
                         self.topic_brokers.insert(
                             format!("{}-{}", topic.topic, partition.id),
                             broker.clone());
@@ -126,6 +155,11 @@ impl KafkaClient {
                     None => {}
                 }
             }
+
+            self.topic_partitions.insert(topic.topic.clone(), known_partitions);
+            known_partitions_internal.sort_by(|a, b| a.partition_id.cmp(&b.partition_id));
+            self.topic_partitions_internal.insert(
+                topic.topic.clone(), TopicPartitions::new(known_partitions_internal));
         }
         Ok(())
     }
@@ -133,6 +167,7 @@ impl KafkaClient {
     /// Clears metadata stored in the client. You must load metadata after this call if you want
     /// to use the client
     pub fn reset_metadata(&mut self) {
+        self.topic_partitions_internal.clear();
         self.topic_partitions.clear();
         self.topic_brokers.clear();
     }
@@ -157,22 +192,16 @@ impl KafkaClient {
         self.topic_brokers.get(&key).map(|b| b.clone())
     }
 
-    fn choose_partition(&mut self, topic: &str) -> Option<i32> {
-        // XXX why doing the lookup twice if once suffices? we should
-        // choose a different structure to hold our data to allow us
-        // doing only one lookup (and avoiding the allocation upon a
-        // not-yet-existing entry)
-
-        match self.topic_partitions.get(topic) {
+    /// Chooses for the given topic a partition to write the next message to.
+    /// Returns the partition_id and the corresponding broker host.
+    fn choose_partition(&mut self, topic: &str) -> Option<(i32, Rc<String>)> {
+        match self.topic_partitions_internal.get_mut(topic) {
             None => None,
-            Some(partitions) if partitions.is_empty() => None,
-            Some(partitions) => {
-                if let Some(curr) = self.topic_partition_curr.get_mut(topic) {
-                    *curr = (*curr+1) % partitions.len() as i32;
-                    return Some(*curr);
-                }
-                self.topic_partition_curr.insert(topic.to_owned(), 1);
-                Some(1)
+            Some(ref topic) if topic.partitions.is_empty() => None,
+            Some(ref mut topic) => {
+                topic.curr_partition_idx = (topic.curr_partition_idx + 1) % topic.partitions.len() as i32;
+                let p = &topic.partitions[topic.curr_partition_idx as usize];
+                Some((p.partition_id, p.broker_host.clone()))
             }
         }
     }
@@ -372,12 +401,10 @@ impl KafkaClient {
 
         // Map topic and partition to the corresponding broker
         for pm in input {
-            if let Some(p) = self.choose_partition(&pm.topic) {
-                if let Some(broker) = self.get_broker(&pm.topic, &p) {
-                    let entry = reqs.entry(broker.clone()).or_insert(
-                        protocol::ProduceRequest::new(required_acks, timeout, correlation, self.clientid.clone(), self.compression));
-                    entry.add(pm.topic, p, pm.message);
-                }
+            if let Some((partition, broker)) = self.choose_partition(&pm.topic) {
+                let entry = reqs.entry(broker).or_insert(
+                    protocol::ProduceRequest::new(required_acks, timeout, correlation, self.clientid.clone(), self.compression));
+                entry.add(pm.topic, partition, pm.message);
             }
         }
 


### PR DESCRIPTION
Surprisingly, avoiding the hash-map look-ups to `topic_brokers` and `topic_partition_curr` increases performance considerably during the `send_messages` use-case. Again, here's some numbers using [monchan](https://github.com/xitep/monchan) to measure the throughput (msg/s):

```
baseline:
$ for i in (seq 25); ./target/release/monchan --brokers 'localhost:9092' produce; end ^| awk '{SUM=SUM+$8} END { print SUM/NR }'
655179

after dropping the topic_partition_curr map:
$ for i in (seq 25); ./target/release/monchan --brokers 'localhost:9092' produce; end ^| awk '{SUM=SUM+$8} END { print SUM/NR }'
778375
```

Avoiding the two hash-maps is achieved by keeping the information in a structure similar to the already existing `topic_partitions` map. Since `topic_partitions` is public, I introduced another which `KafkaClient` now uses internally to avoid a public-api change. Eventually, what is exposed to clients of the library as `KafkaClient#topic_partitions` would be provided through other means (it is problematic anyway.)

I've also measured the impact of this change on fetching messages (brokers are now searched in the more complicated structure using binary-search) instead of a plain hash-map look-up to the previously existing `topic_brokers`: I couldn't measure any performance degradation.
