### PR TITLE
Fetch messages a bit faster

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1379,3 +1379,68 @@ impl FromByte for Message {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use std::io::Cursor;
+
+    use super::FetchResponse;
+    use codecs::FromByte;
+
+    #[test]
+    fn decode_new_fetch_response() {
+
+        // - one topic
+        // - 2 x message of 10 bytes (0..10)
+        // - 2 x message of 5 bytes (0..5)
+        // - 3 x message of 10 bytes (0..10)
+        // - 1 x message of 5 bytes (0..5) static
+        static FETCH_RESPONSE_RAW_DATA: &'static [u8] = &[
+            0, 0, 0, 3, 0, 0, 0, 1, 0, 13, 116, 101, 115, 116, 95,
+            116, 111, 112, 105, 99, 95, 49, 112, 0, 0, 0, 1, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 0, 0, 1, 17, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 24, 211, 120, 76, 139, 0, 0, 255,
+            255, 255, 255, 0, 0, 0, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+            0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 24, 211, 120, 76, 139, 0,
+            0, 255, 255, 255, 255, 0, 0, 0, 10, 0, 1, 2, 3, 4, 5, 6,
+            7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 19, 224, 237,
+            15, 248, 0, 0, 255, 255, 255, 255, 0, 0, 0, 5, 0, 1, 2, 3,
+            4, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 19, 224, 237, 15, 248,
+            0, 0, 255, 255, 255, 255, 0, 0, 0, 5, 0, 1, 2, 3, 4, 0, 0,
+            0, 0, 0, 0, 0, 4, 0, 0, 0, 24, 211, 120, 76, 139, 0, 0,
+            255, 255, 255, 255, 0, 0, 0, 10, 0, 1, 2, 3, 4, 5, 6, 7,
+            8, 9, 0, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 24, 211, 120, 76,
+            139, 0, 0, 255, 255, 255, 255, 0, 0, 0, 10, 0, 1, 2, 3, 4,
+            5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 6, 0, 0, 0, 24, 211,
+            120, 76, 139, 0, 0, 255, 255, 255, 255, 0, 0, 0, 10, 0, 1,
+            2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0, 0, 7, 0, 0, 0,
+            19, 224, 237, 15, 248, 0, 0, 255, 255, 255, 255, 0, 0, 0,
+            5, 0, 1, 2, 3, 4];
+
+        let r = FetchResponse::decode_new(&mut Cursor::new(FETCH_RESPONSE_RAW_DATA));
+        let msgs = r.unwrap().into_messages();
+
+        macro_rules! assert_msg {
+            ($msg:expr, $topic:expr, $partition:expr, $msgdata:expr) => {
+                assert_eq!($topic, &$msg.topic[..]);
+                assert_eq!($partition, $msg.partition);
+                assert_eq!($msgdata, &$msg.message[..]);
+            }
+        }
+
+        assert_eq!(8, msgs.len());
+        let zero_to_ten: Vec<u8> = (0..10).collect();
+        assert_msg!(msgs[0], "test_topic_1p", 0, &zero_to_ten[..]);
+        assert_msg!(msgs[1], "test_topic_1p", 0, &zero_to_ten[..]);
+
+        assert_msg!(msgs[2], "test_topic_1p", 0, &zero_to_ten[0..5]);
+        assert_msg!(msgs[3], "test_topic_1p", 0, &zero_to_ten[0..5]);
+
+        assert_msg!(msgs[4], "test_topic_1p", 0, &zero_to_ten[..]);
+        assert_msg!(msgs[5], "test_topic_1p", 0, &zero_to_ten[..]);
+        assert_msg!(msgs[6], "test_topic_1p", 0, &zero_to_ten[..]);
+
+        assert_msg!(msgs[7], "test_topic_1p", 0, &zero_to_ten[0..5]);
+    }
+}


### PR DESCRIPTION
Here's some speed-up for parsing `FetchResponse`. It looks like all together this makes up a factor of 2 in my (micro-) benchmark (shown below; not committed due to `Bencher` requiring `#![feature(test)]` and, thus, rust nightly).

```
# baseline (master)
test client::benches::bench_get_response_fetch_response ... bench:     434,797 ns/iter (+/- 14,809) = 301 MB/s
test client::benches::bench_get_response_fetch_response ... bench:     431,427 ns/iter (+/- 17,456) = 303 MB/s
test client::benches::bench_get_response_fetch_response ... bench:     435,238 ns/iter (+/- 14,965) = 301 MB/s

# new version
test protocol::benches::bench_decode_fetch_response ... bench:     166,111 ns/iter (+/- 7,592) = 789 MB/s
test protocol::benches::bench_decode_fetch_response ... bench:     166,306 ns/iter (+/- 3,489) = 788 MB/s
test protocol::benches::bench_decode_fetch_response ... bench:     162,644 ns/iter (+/- 4,118) = 806 MB/s
```

The mentioned benchmark:

```
// in protocol.rs

#[cfg(test)]
mod benches {

    use std::fs::File;
    use std::io::Read;
    use std::io::Cursor;
    use test::{black_box, Bencher};

    use super::FetchResponse;
    use error::Result;
    use codecs::FromByte;

    fn get_response<T: FromByte>(data: &[u8]) -> Result<T::R> {
        let v = &data[0..4];
        let size = try!(i32::decode_new(&mut Cursor::new(v)));

        let resp = &data[4..(size + 4) as usize];
        T::decode_new(&mut Cursor::new(resp))
    }

    #[bench]
    fn bench_decode_fetch_response(b: &mut Bencher) {
        let data = {
            let mut data = Vec::with_capacity(256*1024);
            // dump of a previously carried out `get_response::<FetchResponse>()`
            File::open("/tmp/kafka-response.dat").unwrap().read_to_end(&mut data).unwrap();
            data
        };

        b.bytes = data.len() as u64;
        b.iter(|| {
            let r = black_box(get_response::<FetchResponse>(&data));
            let msgs = black_box(r.unwrap().into_messages());
            // println!("msgs: {}", msgs.len());
        });
    }
}
```

On real workloads, however, this patch has probably only the effect of a slightly decreased cpu-utilization since kafka-reading applications will probably hit far more likely other bottlenecks (performance of the remote kafka-instance, network, etc.). Here's the output of [monchan](https://github.com/xitep/monchan) consuming a 10 partition topic as fast as possible:

```
# baseline (master)
DEBUG:monchan: topic: foobar_topic, total msgs: 12200000 (errors: 0), bytes: 5655741890, elapsed: 154644ms ==> msg/s: 78890.87
^CCommand terminated by signal 2
	Command being timed: "./monchan.baseline --brokers=... --topics=foobar_topic consume"
	User time (seconds): 43.92
	System time (seconds): 75.40
	Percent of CPU this job got: 76%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 2:35.08
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 3652
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 9683934
	Voluntary context switches: 143746
	Involuntary context switches: 628
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0

# new version
DEBUG:monchan: topic: foobar_topic, total msgs: 12300000 (errors: 0), bytes: 5702851504, elapsed: 153990ms ==> msg/s: 79875.32
^CCommand terminated by signal 2
	Command being timed: "./monchan.final2 --brokers=... --topics=foobar_topic consume"
	User time (seconds): 30.38
	System time (seconds): 79.22
	Percent of CPU this job got: 70%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 2:34.39
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 3696
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 0
	Minor (reclaiming a frame) page faults: 6095807
	Voluntary context switches: 127931
	Involuntary context switches: 596
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0

```

This change is backwards compatible with the current public api.