### PR TITLE
Fix panic upon fetching offsets

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -366,14 +366,14 @@ impl OffsetRequest {
         }
     }
 
-    pub fn add(&mut self, topic: String, partition: i32, time: i64) {
+    pub fn add(&mut self, topic: &str, partition: i32, time: i64) {
         for tp in &mut self.topic_partitions {
             if tp.topic == topic {
                 tp.add(partition, time);
                 return;
             }
         }
-        let mut tp = TopicPartitionOffsetRequest::new(topic.clone());
+        let mut tp = TopicPartitionOffsetRequest::new(topic.to_owned());
         tp.add(partition, time);
         self.topic_partitions.push(tp);
     }
@@ -546,7 +546,7 @@ impl FetchRequest {
                 return;
             }
         }
-        let mut tp = TopicPartitionFetchRequest::new(topic.clone());
+        let mut tp = TopicPartitionFetchRequest::new(topic);
         tp.add(partition, offset);
         self.topic_partitions.push(tp);
     }

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -404,7 +404,7 @@ impl PartitionOffsetRequest {
 }
 
 impl OffsetResponse {
-    pub fn get_offsets(&self) -> Vec<TopicPartitionOffsetError>{
+    pub fn get_offsets(&self) -> Vec<TopicPartitionOffsetError> {
         self.topic_partitions
             .iter()
             .flat_map(|ref tp| tp.get_offsets(tp.topic.clone()))
@@ -413,7 +413,7 @@ impl OffsetResponse {
 }
 
 impl TopicPartitionOffsetResponse {
-    pub fn get_offsets(&self, topic: String) -> Vec<TopicPartitionOffsetError>{
+    pub fn get_offsets(&self, topic: String) -> Vec<TopicPartitionOffsetError> {
         self.partitions
             .iter()
             .map(|ref p| p.get_offsets(topic.clone()))
@@ -422,11 +422,14 @@ impl TopicPartitionOffsetResponse {
 }
 
 impl PartitionOffsetResponse {
-    pub fn get_offsets(&self, topic: String) -> TopicPartitionOffsetError{
+    pub fn get_offsets(&self, topic: String) -> TopicPartitionOffsetError {
         TopicPartitionOffsetError{
             topic: topic,
             partition: self.partition,
-            offset:self.offset[0],
+            offset: match self.offset.first() {
+                Some(offs) => *offs,
+                None => -1,
+            },
             error: Error::from_i16(self.error)
         }
     }
@@ -717,7 +720,7 @@ impl PartitionOffsetFetchResponse {
         TopicPartitionOffsetError{
             topic: topic,
             partition: self.partition,
-            offset:self.offset,
+            offset: self.offset,
             error: Error::from_i16(self.error)
         }
     }


### PR DESCRIPTION
* Having specified a [weird "time"](http://grokbase.com/t/kafka/users/143eqcym20/about-offsetrequest-time-field) to `fetch_offsets` I received a panic, as Kafka seems not to send any offset at all (unfortunatelly not even an error) in such a situation. For the moment the fix supplies a `-1` for the missing offset which is delivered to the user in the end - not sure this is the right course of action. At least users can react on this (by querying again for the latest offset for example).
* The second commit is merely some clean-up I did while testing the `fetch_offsets` method.

PS: I'll be off for about a week, so I might not response for some time.