### PR TITLE
Allocation friendly fetch-offset-api

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kafka"
-version = "0.1.8"
+version = "0.2.0"
 authors = ["Yousuf Fauzan https://github.com/spicavigo"]
 description = "Rust client for Apache Kafka"
 homepage = "https://github.com/spicavigo/kafka-rust"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ use kafka::client::{KafkaClient, FetchOffset};
 fn main() {
     let mut client = KafkaClient::new(vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
-    let offsets = client.fetch_topic_offset("my-topic".to_owned(), FetchOffset::Latest);
+    let offsets = client.fetch_topic_offset("my-topic", FetchOffset::Latest);
 }
 ```
 
@@ -54,8 +54,8 @@ use kafka::client::{KafkaClient, FetchOffset};
 fn main() {
     let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
-    let topics = client.topic_partitions.keys().cloned().collect();
-    let offsets = client.fetch_offsets(topics, FetchOffset::Latest);
+    let topics: Vec<String> = client.topic_partitions.keys().cloned().collect();
+    let offsets = client.fetch_offsets(&topics, FetchOffset::Latest);
 }
 ```
 ##### Produce:

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ fn main() {
 
 ```rust
 extern crate kafka;
-use kafka::client::KafkaClient;
+use kafka::client::{KafkaClient, FetchOffset};
 fn main() {
     let mut client = KafkaClient::new(vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
-    let offsets = client.fetch_topic_offset("my-topic".to_owned(), -1);
+    let offsets = client.fetch_topic_offset("my-topic".to_owned(), FetchOffset::Latest);
 }
 ```
 
@@ -50,12 +50,12 @@ fn main() {
 
 ```rust
 extern crate kafka;
-use kafka::client::KafkaClient;
+use kafka::client::{KafkaClient, FetchOffset};
 fn main() {
     let mut client = KafkaClient::new(&vec!("localhost:9092".to_owned()));
     client.load_metadata_all();
     let topics = client.topic_partitions.keys().cloned().collect();
-    let offsets = client.fetch_offsets(topics, -1);
+    let offsets = client.fetch_offsets(topics, FetchOffset::Latest);
 }
 ```
 ##### Produce:

--- a/examples/consume.rs
+++ b/examples/consume.rs
@@ -1,5 +1,6 @@
 extern crate kafka;
-use kafka::client::KafkaClient;
+
+use kafka::client::{KafkaClient, FetchOffset};
 
 /// This program demonstrates consuming messages through `KafkaClient`. This is the top level
 /// client that will fit most use cases. Note that consumed messages are tracked by Kafka so you
@@ -26,7 +27,7 @@ fn main() {
     }
 
     let con = kafka::consumer::Consumer::new(client, "test-group".to_owned(), topic.to_owned())
-        .fallback_offset(-2);
+        .fallback_offset(FetchOffset::Earliest);
 
     for msg in con {
         println!("{:?}", msg);

--- a/src/client.rs
+++ b/src/client.rs
@@ -79,7 +79,7 @@ impl TopicPartitions {
 
 /// Possible values when querying a topic's offset.
 /// See `KafkaClient::fetch_offsets`.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum FetchOffset {
     /// Receive the earliest available offset.
     Earliest,
@@ -325,7 +325,12 @@ impl KafkaClient {
                                              -> Result<Vec<utils::PartitionOffset>>
     {
         let mut m = try!(self.fetch_offsets(&[topic.as_ref()], offset));
-        Ok(m.remove(topic.as_ref()).unwrap_or(vec!()))
+        let offs = m.remove(topic.as_ref()).unwrap_or(vec!());
+        if offs.is_empty() {
+            Err(Error::UnknownTopicOrPartition)
+        } else {
+            Ok(offs)
+        }
     }
 
     /// Fetch messages from Kafka (Multiple topic, partition, offset)

--- a/src/client.rs
+++ b/src/client.rs
@@ -86,8 +86,8 @@ pub enum FetchOffset {
     /// Receive the latest offset.
     Latest,
     /// Used to ask for all messages before a certain time (ms); unix
-    /// timestamp in milliseconds.  See
-    /// http://grokbase.com/t/kafka/users/12cherxwf5/fetch-messages-since-a-specific-time
+    /// timestamp in milliseconds.  See also
+    /// https://cwiki.apache.org/confluence/display/KAFKA/Writing+a+Driver+for+Kafka#WritingaDriverforKafka-Offsets
     ByTime(i64),
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -300,17 +300,10 @@ impl KafkaClient {
         let mut res: HashMap<String, Vec<utils::PartitionOffset>> = HashMap::with_capacity(n_topics);
         for (host, req) in reqs {
             let resp = try!(self.send_receive::<protocol::OffsetRequest, protocol::OffsetResponse>(&host, req));
-            for tp in resp.get_offsets() {
-                // XXX do return errors
-                match tp.error {
-                    None => {
-                        let entry = res.entry(tp.topic).or_insert(vec!());
-                        entry.push(utils::PartitionOffset{offset:tp.offset, partition: tp.partition});
-                    }
-                    _ => {}
-                    // Some(e) => {
-                    //     println!("offset error for {}:{}: {}", tp.topic, tp.partition, e);
-                    // }
+            for tp in resp.topic_partitions {
+                let e = res.entry(tp.topic).or_insert(vec!());
+                for p in tp.partitions {
+                    e.push(p.into_offset());
                 }
             }
         }

--- a/src/codecs.rs
+++ b/src/codecs.rs
@@ -50,8 +50,16 @@ impl ToByte for i64 {
         buffer.write_i64::<BigEndian>(*self).or_else(|e| Err(From::from(e)))
     }
 }
+
 impl ToByte for String {
-    fn encode<T:Write>(&self, buffer: &mut T) -> Result<()> {
+    fn encode<T: Write>(&self, buffer: &mut T) -> Result<()> {
+        let s: &str = self;
+        s.encode(buffer)
+    }
+}
+
+impl ToByte for str {
+    fn encode<T: Write>(&self, buffer: &mut T) -> Result<()> {
         let l = try!(self.len()
                         .to_i16()
                         .ok_or(Error::CodecError));
@@ -61,7 +69,7 @@ impl ToByte for String {
     }
 }
 
-impl <V:ToByte> ToByte for Vec<V> {
+impl <V: ToByte> ToByte for Vec<V> {
     fn encode<T:Write>(&self, buffer: &mut T) -> Result<()> {
         let l = try!(self.len()
                         .to_i32()
@@ -80,7 +88,7 @@ impl <V:ToByte> ToByte for Vec<V> {
     }
 }
 
-impl ToByte for Vec<u8>{
+impl ToByte for Vec<u8> {
     fn encode<T: Write>(&self, buffer: &mut T) -> Result<()> {
         let l = try!(self.len()
                         .to_i32()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,8 @@
 //! Some utility structures
 
-use error::Error;
+use error::{Result,Error};
 
+// XXX move to protocol module
 #[derive(Clone, Debug)]
 pub struct OffsetMessage {
     pub offset: i64,
@@ -23,11 +24,10 @@ pub struct ProduceMessage {
     pub message: Vec<u8>
 }
 
-
 #[derive(Debug)]
 pub struct PartitionOffset {
     pub partition: i32,
-    pub offset: i64
+    pub offset: Result<i64>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This changeset builds up on #32. This time, it's a public API change though. It ...

* ... avoids magic constants (inherited from kafka) by introducing an explicit enum.
* ... proposes an API to `KafkaClient::fetch_offsets` and `KafkaClient::fetch_topic_offset` such that clients are not forced to re-allocated the specified topics over and over again (if the concept is fine, we can apply it to the rest of `KafkaClient`.)
* ... makes the two mentioned methods return the error if kafka delivers one for the fetched offsets (here `PartitionOffset#offset` changes to a `Result<i64>` to force clients to evaluate the error if any; also here I'd favor if we applied this to the rest of `KafkaClient`.)
* ... during the execution of the two mentioned methods topic names are not cloned needlessly anymore.

However, there's still one annonying fact: The following will produce an error:

```
    let topics: Vec<&String> = client.topic_partitions.keys()/*.cloned()*/.collect();
    let offs = try!(client.fetch_offsets(&topics, FetchOffset::Latest));

... compiler goes mad:

    main.rs:131:21: 131:27 error: cannot borrow `client` as mutable because `client.topic_partitions` is also borrowed as immutable [E0502]
    main.rs:131     let offs = try!(client.fetch_offsets(&topics, FetchOffset::Latest));
                                    ^~~~~~
    ...
```

Right now, a `.clone()` is still necessary once in the program (to work around the borrowck). The final solution will very likely be to return the metadata from `load_metadata()` to clients and fully drop the public `KafkaClient#topic_partitions`. I would consider this step only after all of `KafkaClient`'s methods are reworked similarly to the proposed `fetch_offsets`.

@spicavigo, I would really greatly appreciate if you could find some time and have a critical look on the proposed changes. I want to be more confident I'm going into the right direction before making further changes.
