### PR TITLE
Fix initializing start offsets when missing for consumer-group

### DIFF
--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1,8 +1,8 @@
 //! Kafka Consumer
 //!
 //! A simple consumer based on KafkaClient. Accepts an instance of KafkaClient, a group and a
-//! topic. Partitions can be specfied using builder pattern (Assumes all partitions if not
-//! specfied).
+//! topic. Partitions can be specified using builder pattern (Assumes all partitions if not
+//! specified).
 //!
 //! # Example
 //!
@@ -10,20 +10,21 @@
 //! let mut client = kafka::client::KafkaClient::new(vec!("localhost:9092".to_owned()));
 //! let res = client.load_metadata_all();
 //! let con = kafka::consumer::Consumer::new(client, "test-group".to_owned(), "my-topic".to_owned())
-//!             .partition(0);
+//!             .partition(0)
+//!             .fallback_offset(-2);
 //! for msg in con {
 //!     println!("{:?}", msg);
 //! }
 //! ```
 //!
-//! Consumer auto-commits the offsets afer consuming COMMIT_INTERVAL messages (Currently set at
+//! Consumer auto-commits the offsets after consuming COMMIT_INTERVAL messages (Currently set at
 //! 100)
 //!
 //! Consumer implements Iterator.
 
 use std::collections::HashMap;
-use error::Result;
-use utils::{TopicMessage, TopicPartitionOffset};
+use error::{Error, Result};
+use utils::{TopicMessage, TopicPartitionOffset, TopicPartitionOffsetError};
 use client::KafkaClient;
 
 const COMMIT_INTERVAL: i32 = 100; // Commit after every 100 message
@@ -38,10 +39,13 @@ pub struct Consumer {
     messages: Vec<TopicMessage>,
     index: usize,
     offsets: HashMap<i32, i64>,
-    consumed: i32
+    consumed: i32,
+
+    fallback_offset: Option<i64>,
 }
 
 impl Consumer {
+
     /// Constructor
     ///
     /// Create a new consumer. Expects a KafkaClient, group, and topic as arguments.
@@ -65,6 +69,26 @@ impl Consumer {
         self
     }
 
+    /// Specify the offset to use when none was committed for the
+    /// underlying group yet.
+    ///
+    /// Running the underlying group for the first time against a
+    /// topic results in the question where to start reading from the
+    /// topic?  It might already contain a lot of messages.  Common
+    /// strategies are starting at the earliest available message
+    /// (thereby consuming whatever is currently in the topic) or at
+    /// the latest one (thereby staring to consume only newly arriving
+    /// messages.)  The parameter here corresponds to `time` in
+    /// `KafkaClient::fetch_offsets`.
+    ///
+    /// Unless this method is called and there is no offset committed
+    /// for the underlying group yet, this consumer will _not_ retrieve
+    /// any messages from the underlying topic.
+    pub fn fallback_offset(mut self, fallback_offset_time: i64) -> Consumer {
+        self.fallback_offset = Some(fallback_offset_time);
+        self
+    }
+
     fn commit_offsets(&mut self) -> Result<()> {
         let tpos = self.offsets.iter()
                         .map(|(p, o)| TopicPartitionOffset{
@@ -77,11 +101,18 @@ impl Consumer {
     }
 
     fn fetch_offsets(&mut self) -> Result<()> {
-        let tpos = try!(self.client.fetch_group_topic_offset(self.group.clone(), self.topic.clone()));
+        // ~ fetch the so far commited group offsets
+        let mut tpos = try!(self.client.fetch_group_topic_offset(self.group.clone(), self.topic.clone()));
         if self.partitions.len() == 0 {
             self.partitions = self.client.topic_partitions.get(&self.topic).unwrap_or(&vec!()).clone();
         }
-        for tpo in tpos {
+
+        // ~ it might well that there were no group offsets committed
+        // yet ... fallback to default offsets.
+        try!(self.set_fallback_offsets(&mut tpos));
+
+        // ~ now initialized from the fetched offsets
+        for tpo in &tpos {
             if self.partitions.contains(&tpo.partition) {
                 self.offsets.insert(tpo.partition, tpo.offset);
             }
@@ -89,7 +120,46 @@ impl Consumer {
         Ok(())
     }
 
-    fn make_request(&mut self) -> Result<()>{
+    /// Try setting the "fallback offsets" for all of `tpos` where
+    /// `offset == -1`. Fails if retrieving the fallback offset is not
+    /// possible for some reason for the affected elements from
+    /// `tpos`.
+    fn set_fallback_offsets(&mut self, tpos: &mut [TopicPartitionOffsetError]) -> Result<()> {
+        // ~ it looks like kafka (0.8.2.1) is sending an error code
+        // (even though it documents it won't: https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-OffsetFetchResponse)
+        // so let's check only for `offset == -1` (and don't verify `error == None`)
+        let has_missing_offs = tpos.iter().filter(|tpo| tpo.offset == -1).next().is_some();
+        if has_missing_offs {
+            // ~ if the user specified a "fallback offset" strategy
+            // will try to fetch the current offset for that strategy
+            // and start consuming starting at those
+            if let Some(fallback_offset) = self.fallback_offset {
+                // ~ now fetch the offset according to the specified strategy
+                let new_offs = {
+                    let mut r = try!(self.client.fetch_topic_offset(self.topic.clone(), fallback_offset));
+                    match r.remove(&self.topic) {
+                        None => return Err(Error::UnknownTopicOrPartition),
+                        Some(pts) => pts,
+                    }
+                };
+                // ehm ... not really fast (O(n^2))
+                for tpo in tpos.iter_mut() {
+                    if tpo.offset == -1 {
+                        if let Some(new_off) = new_offs.iter().find(|pt| pt.partition == tpo.partition) {
+                            tpo.offset = new_off.offset;
+                            tpo.error = None;
+                        }
+                    }
+                }
+            } else {
+                // XXX might want to produce some log message and return a dedicated error code
+                return Err(Error::Unknown);
+            }
+        }
+        Ok(())
+    }
+
+    fn make_request(&mut self) -> Result<()> {
         if ! self.initialized {
             try!(self.fetch_offsets());
         }


### PR DESCRIPTION
This is an attempt to allow clients specifying the course of action upon starting to read topics using `Consumers` for the first time under a group (and not have the consumer fail silently). The API is now:

```
let consumer = Consumer::new(...).fallback_offset(-2); // or -1
for msg in consumer { ... }
```

`-1` and `-2` here correspond to the `time` parameter of `fetch_offsets` meaning `FetchOffset::Latest` and `FetchOffset::Earliest`, respectively. Given that `Consumer` stops iterating upon receiving no messages from kafka within 100ms, `-1` is a bit meaningless currently. The default behaviour is kept unchanged. This is luckily a backwards compatible change.

There is still one more problem, though. This PR does not try to address the problem where the committed offset is out-of-date, e.g. already non-existent in kafka any more (due to rolled logs in kafka). I think we can address this later.