### PR TITLE
Skip messages already as part of KafkaClient#fetch_messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ crc = "1.2"
 log = "0.3"
 snappy = "0.3"
 ref_slice = "1.0"
+fnv = "1.0"
 
 [dev-dependencies]
 getopts = "0.2"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -619,21 +619,23 @@ impl KafkaClient {
     /// greater than zero.
     ///
     /// The result is exposed in a raw, complicated manner but allows
-    /// for very efficient consumption possibilities.  In particular,
-    /// each of the returned fetch responses directly corresponds to
-    /// fetch requests to the underlying kafka brokers.  Except of
-    /// transparently uncompressing compressed messages, the result is
-    /// not otherwise prepared.
+    /// for very efficient consumption possibilities. All of the data
+    /// available through the returned fetch responses is bound to
+    /// their lifetime as that data is merely a "view" into parts of
+    /// the response structs.  If you need to keep individual messages
+    /// for a longer time than the whole fetch responses, you'll need
+    /// to make a copy of the message data.
     ///
-    /// All of the data available through the returned fetch responses
-    /// is bound to their lifetime as that data is merely a "view"
-    /// into parts of the response structs.  If you need to keep
-    /// individual messages for a longer time than the whole fetch
-    /// responses, you'll need to make a copy of the message data.
+    /// * This method transparently uncompresses messages (while Kafka
+    /// might sent them in compressed format.)
+    ///
+    /// * This method ensures to skip messages with a lower offset
+    /// than requested (while Kafka might for efficiency reasons sent
+    /// messages with a lower offset.)
     ///
     /// Note: before using this method consider using
-    /// `kafka::consumer::Consumer` instead which provides a much
-    /// easier API for the use-case of fetching messesage from Kafka.
+    /// `kafka::consumer::Consumer` instead which provides an to use
+    /// API for the use-case of fetching messesage from Kafka.
     ///
     /// # Example
     ///
@@ -711,9 +713,6 @@ impl KafkaClient {
     pub fn fetch_messages_for_partition<'a>(&mut self, req: &FetchPartition<'a>)
                                             -> Result<Vec<fetch::Response>>
     {
-        // XXX since we deal with exactly one partition we can generate
-        // the fetch request to the corresponding kafka broker more
-        // efficiently
         self.fetch_messages(&[req])
     }
 
@@ -941,14 +940,15 @@ fn __fetch_messages(conn_pool: &mut ConnectionPool,
                     reqs: HashMap<&str, protocol::FetchRequest>)
                     -> Result<Vec<fetch::Response>>
 {
-    let p = protocol::fetch::ResponseParser {
-        validate_crc: config.fetch_crc_validation,
-    };
-
     // Call each broker with the request formed earlier
     let mut res = Vec::with_capacity(reqs.len());
     for (host, req) in reqs {
-        res.push(try!(__z_send_receive::<protocol::FetchRequest, _>(conn_pool, host, req, &p)));
+        let p = protocol::fetch::ResponseParser {
+            validate_crc: config.fetch_crc_validation,
+            requests: Some(&req),
+        };
+
+        res.push(try!(__z_send_receive::<&protocol::FetchRequest, _>(conn_pool, host, &req, &p)));
     }
     Ok(res)
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -634,8 +634,9 @@ impl KafkaClient {
     /// messages with a lower offset.)
     ///
     /// Note: before using this method consider using
-    /// `kafka::consumer::Consumer` instead which provides an to use
-    /// API for the use-case of fetching messesage from Kafka.
+    /// `kafka::consumer::Consumer` instead which provides an easier
+    /// to use API for the regular use-case of fetching messesage from
+    /// Kafka.
     ///
     /// # Example
     ///

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -45,6 +45,9 @@
 use std::collections::hash_map::{HashMap, Entry};
 use std::collections::VecDeque;
 use std::slice;
+use std::hash::BuildHasherDefault;
+
+use fnv::FnvHasher;
 
 use client::{self, KafkaClient, FetchPartition, CommitOffset, FetchGroupOffset};
 use client::metadata::Topics;
@@ -57,6 +60,8 @@ pub use client::FetchOffset;
 
 /// The default value for `Builder::with_retry_max_bytes_limit`.
 pub const DEFAULT_RETRY_MAX_BYTES_LIMIT: i32 = 0;
+
+type PartitionHasher = BuildHasherDefault<FnvHasher>;
 
 /// The Kafka Consumer
 ///
@@ -80,7 +85,7 @@ struct FetchState {
 struct State {
     /// Contains the information relevant for the next fetch operation
     /// on the corresponding partitions
-    fetch_offsets: HashMap<i32, FetchState>,
+    fetch_offsets: HashMap<i32, FetchState, PartitionHasher>,
 
     /// Specifies partitions to be fetched on their own in the next
     /// poll request.
@@ -88,7 +93,7 @@ struct State {
 
     /// Contains the offsets of messages marked as "consumed" (to be
     /// committed)
-    consumed_offsets: HashMap<i32, i64>,
+    consumed_offsets: HashMap<i32, i64, PartitionHasher>,
 
     /// `true` iff the consumed_offsets contain data which needs to be
     /// committed. Set to `false` after commit.
@@ -406,7 +411,7 @@ fn determine_partitions(config: &Config, metadata: Topics) -> Result<Vec<i32>> {
 // Fetches the so-far commited/consumed offsets for the configured
 // group/topic/partitions.
 fn load_consumed_offsets(config: &Config, client: &mut KafkaClient, partitions: &[i32])
-                         -> Result<HashMap<i32, i64>>
+                         -> Result<HashMap<i32, i64, PartitionHasher>>
 {
     assert!(!partitions.is_empty());
 
@@ -415,7 +420,8 @@ fn load_consumed_offsets(config: &Config, client: &mut KafkaClient, partitions: 
         &config.group,
         partitions.iter().map(|&p_id | FetchGroupOffset::new(topic, p_id))));
 
-    let mut offs = HashMap::with_capacity(partitions.len());
+    let mut offs = HashMap::with_capacity_and_hasher(partitions.len(),
+                                                     PartitionHasher::default());
     for tpo in tpos {
         match tpo.offset {
             Ok(o) if o != -1 => {
@@ -432,14 +438,14 @@ fn load_consumed_offsets(config: &Config, client: &mut KafkaClient, partitions: 
 fn load_fetch_states(config: &Config,
                       client: &mut KafkaClient,
                       partitions: &[i32],
-                      consumed_offsets: &HashMap<i32, i64>)
-                      -> Result<HashMap<i32, FetchState>>
+                      consumed_offsets: &HashMap<i32, i64, PartitionHasher>)
+                      -> Result<HashMap<i32, FetchState, PartitionHasher>>
 {
     fn load_partition_offsets(client: &mut KafkaClient, topic: &str, offset: FetchOffset)
-                              -> Result<HashMap<i32, i64>>
+                              -> Result<HashMap<i32, i64, PartitionHasher>>
     {
         let offs = try!(client.fetch_topic_offsets(topic, offset));
-        let mut m = HashMap::with_capacity(offs.len());
+        let mut m = HashMap::with_capacity_and_hasher(offs.len(), PartitionHasher::default());
         for off in offs {
             m.insert(off.partition, off.offset.unwrap_or(-1));
         }
@@ -455,7 +461,7 @@ fn load_fetch_states(config: &Config,
     // ~ for each partition if we have a consumed_offset verify it is
     // in the earliest/latest range and use that consumed_offset+1 as
     // the fetch_message.
-    let mut fetch_offsets = HashMap::new();
+    let mut fetch_offsets = HashMap::default();
     for p in partitions {
         let (&l_off, &e_off) = (latest.get(p).unwrap_or(&-1), earliest.get(p).unwrap_or(&-1));
         let offset = match consumed_offsets.get(p) {

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -212,12 +212,6 @@ impl Consumer {
                     let mut fetch_state = self.state.fetch_offsets
                             .get_mut(&partition)
                             .expect("non-requested partition");
-                    // ~ make sure we skip messages we have not asked
-                    // for in further processing
-                    // XXX move functionality directly into the code which parses the protocol data
-                    unsafe {
-                        data.forget_before_offset(fetch_state.offset);
-                    }
                     // ~ book keeping
                     if let Some(last_msg) = data.messages().last() {
                         fetch_state.offset = last_msg.offset + 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ extern crate flate2;
 extern crate crc;
 extern crate snappy;
 extern crate ref_slice;
+extern crate fnv;
 
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
* Resolves #80.
* Drop public `unsafe fn forget_before_offset` from fetch response.
* Use fnv hasher for partition based hash maps (consumer and fetch message parsing)
