### PR TITLE
Genericize consumer builder API.

### DIFF
--- a/src/consumer/builder.rs
+++ b/src/consumer/builder.rs
@@ -69,8 +69,8 @@ impl Builder {
     ///
     /// The group is allowed to be the empty string, in which case the
     /// resulting consumer will be group-less.
-    pub fn with_group(mut self, group: String) -> Builder {
-        self.group = group;
+    pub fn with_group<S: Into<String>>(mut self, group: S) -> Builder {
+        self.group = group.into();
         self
     }
 
@@ -83,8 +83,8 @@ impl Builder {
     ///
     /// This method or `with_topic_partitions` must be called at least
     /// once, to assign a topic to the consumer.
-    pub fn with_topic(mut self, topic: String) -> Builder {
-        self.assignments.insert(topic, Vec::new());
+    pub fn with_topic<S: Into<String>>(mut self, topic: S) -> Builder {
+        self.assignments.insert(topic.into(), Vec::new());
         self
     }
 
@@ -97,8 +97,8 @@ impl Builder {
     ///
     /// This method or `with_topic` must be called at least once, to
     /// assign a topic to the consumer.
-    pub fn with_topic_partitions(mut self, topic: String, partitions: &[i32]) -> Builder {
-        self.assignments.insert(topic, partitions.to_vec());
+    pub fn with_topic_partitions<S: Into<String>>(mut self, topic: S, partitions: &[i32]) -> Builder {
+        self.assignments.insert(topic.into(), partitions.to_vec());
         self
     }
 

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -106,8 +106,10 @@ impl Consumer {
 
     /// Starts building a consumer bootstraping internally a new kafka
     /// client from the given kafka hosts.
-    pub fn from_hosts(hosts: Vec<String>) -> Builder {
-        builder::new(None, hosts)
+    pub fn from_hosts<S, H>(hosts: H) -> Builder
+        where S: Into<String>,
+              H: IntoIterator<Item = S> {
+        builder::new(None, hosts.into_iter().map(|s| s.into()).collect::<Vec<_>>())
     }
 
     /// Destroys this consumer returning back the underlying kafka client.


### PR DESCRIPTION
Uses `Into<String>` and `IntoIterator<Item=_>` to genericize the builder API.

This _is_ in fact a breaking API change, unfortunately. Consider this example:

```rust
let builder = Consumer::from_hosts(Default::default());
```

This will not compile without generics specified on the argument in this PR. Before, it would work. Something to consider when merging. However, you should no longer _need_ to call `to_owned()`/`String::from(_)`/etc on builder arguments.

The examples still need to be adjusted to take advantage of this.

Resolves #120 