### PR TITLE
Add way to consumer and producer to borrow client

### DIFF
--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -109,8 +109,13 @@ impl Consumer {
         builder::new(None, hosts)
     }
 
+    /// Borrow the underlying kafka client
+    pub fn client(&self) -> &KafkaClient {
+        &self.client
+    }
+
     /// Destroys this consumer returning back the underlying kafka client.
-    pub fn client(self) -> KafkaClient {
+    pub fn into_client(self) -> KafkaClient {
         self.client
     }
 

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -236,8 +236,13 @@ impl Producer {
         Builder::new(None, hosts)
     }
 
+    /// Borrow the underlying kafka client
+    pub fn client(&self) -> &KafkaClient {
+        &self.client
+    }
+
     /// Destroys this producer returning the underlying kafka client.
-    pub fn client(self) -> KafkaClient {
+    pub fn into_client(self) -> KafkaClient {
         self.client
     }
 }


### PR DESCRIPTION
I have a use case where I need to know the partition assignments of a given consumer. This pull introduces a way to borrow a read only client so you can retrieve information from it.