### PR TITLE
Add client_mut function to Consumer

### DIFF
--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -115,6 +115,11 @@ impl Consumer {
         &self.client
     }
 
+    /// Borrows the underlying kafka client as mut.
+    pub fn client_mut(&mut self) -> &mut KafkaClient {
+        &mut self.client
+    }
+
     /// Destroys this consumer returning back the underlying kafka client.
     pub fn into_client(self) -> KafkaClient {
         self.client


### PR DESCRIPTION
Lets us get a mut client. This helped me when doing `reset_metadata()`. The doc string might need to change, whatever you like.