### PR TITLE
Fix off by one error in Consumer commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,5 @@ env:
   matrix:
     - KAFKA_VER=0.8.2.2
     - KAFKA_VER=0.9.0.1
+    - KAFKA_VER=0.10.2.1
     - KAFKA_VER=latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ openssl = { version = "0.9", optional = true }
 getopts = "0.2"
 env_logger = { version = "0.3", default-features = false }
 time = "0.1"
+rand = "0.3"
 
 
 [features]

--- a/src/consumer/builder.rs
+++ b/src/consumer/builder.rs
@@ -90,7 +90,7 @@ impl Builder {
         self
     }
 
-    /// Explicetely specifies topic partitions to consume. Only the
+    /// Explicitly specifies topic partitions to consume. Only the
     /// specified partitions for the identified topic will be consumed
     /// unless overriden later using `with_topic`.
     ///

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -183,7 +183,7 @@ impl Consumer {
                 };
                 let topic = self.state.topic_name(tp.topic_ref);
                 debug!(
-                    "fetching messages: (fetch-offset: {{\"{}:{}\": {:?}}})",
+                    "fetching retry messages: (fetch-offset: {{\"{}:{}\": {:?}}})",
                     topic,
                     tp.partition,
                     s
@@ -427,7 +427,13 @@ impl Consumer {
                     .filter(|&(_, o)| o.dirty)
                     .map(|(tp, o)| {
                         let topic = state.topic_name(tp.topic_ref);
-                        CommitOffset::new(topic, tp.partition, o.offset)
+
+                        // Note that the offset that is committed should be the
+                        // offset of the next message a consumer should read, so
+                        // add one to the consumed message's offset.
+                        //
+                        // https://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html
+                        CommitOffset::new(topic, tp.partition, o.offset + 1)
                     }),
             )
         );

--- a/tests/integration/consumer_producer/consumer.rs
+++ b/tests/integration/consumer_producer/consumer.rs
@@ -1,6 +1,15 @@
 use super::*;
+
+use std::collections::HashMap;
+
 use kafka::producer::Record;
 use kafka::error;
+
+use env_logger;
+use rand;
+use rand::Rng;
+
+const RANDOM_MESSAGE_SIZE: usize = 32;
 
 /// Tests that consuming one message works
 #[test]
@@ -25,6 +34,88 @@ fn test_consumer_poll() {
 
     let message_content = message_set.messages()[0].value;
     assert_eq!(correct_message_contents, message_content, "incorrect message contents");
+}
+
+/// Test Consumer::commit_messageset
+#[test]
+fn test_consumer_commit_messageset() {
+    env_logger::init().unwrap();
+
+    let mut consumer = test_consumer();
+
+    // get the offsets at the beginning of the test
+    let start_offsets = {
+        let mut client = new_ready_kafka_client();
+        client
+            .fetch_group_topic_offsets(TEST_GROUP_NAME, TEST_TOPIC_NAME)
+            .unwrap()
+            .iter()
+            .map(|po| (po.partition, if po.offset != -1 { po.offset } else { 0 }))
+            .collect::<HashMap<i32, i64>>()
+    };
+
+    debug!("start offsets: {:?}", start_offsets);
+
+    // poll once to set a position in the topic
+    let messages = consumer.poll().unwrap();
+    assert!(messages.is_empty(), "messages was not empty: {:?}", messages);
+
+    let mut random_message_buf = [0u8; RANDOM_MESSAGE_SIZE];
+    let mut rng = rand::thread_rng();
+    let mut producer = test_producer();
+
+    // send some messages to the topic
+    const NUM_MESSAGES: i64 = 100;
+
+    for _ in 0..NUM_MESSAGES {
+        rng.fill_bytes(&mut random_message_buf);
+        producer
+            .send(&Record::from_value(TEST_TOPIC_NAME, &random_message_buf[..]))
+            .unwrap();
+    }
+
+    let mut num_messages = 0;
+
+    'read: loop {
+        for ms in consumer.poll().unwrap().iter() {
+            let messages = ms.messages();
+            num_messages += messages.len();
+            consumer.consume_messageset(ms).unwrap();
+        }
+
+        consumer.commit_consumed().unwrap();
+
+        if num_messages >= (NUM_MESSAGES as usize) {
+            break 'read;
+        }
+    }
+
+    assert_eq!(NUM_MESSAGES as usize, num_messages, "wrong number of messages");
+
+    // get the latest offsets and make sure they add up to the number of messages
+    let latest_offsets = {
+        let mut client = consumer.into_client();
+        client.load_metadata_all().unwrap();
+        client
+            .fetch_group_topic_offsets(TEST_GROUP_NAME, TEST_TOPIC_NAME)
+            .unwrap()
+            .iter()
+            .map(|po| (po.partition, po.offset))
+            .collect::<HashMap<i32, i64>>()
+    };
+
+    debug!("end offsets: {:?}", latest_offsets);
+
+    // add up the differences
+    let num_new_messages_committed: i64 = latest_offsets
+        .iter()
+        .map(|(partition, new_offset)| {
+            let old_offset = start_offsets.get(partition).unwrap();
+            new_offset - old_offset
+        })
+        .sum();
+
+    assert_eq!(NUM_MESSAGES, num_new_messages_committed, "wrong number of messages committed");
 }
 
 /// Consuming from a non-existent topic should fail.

--- a/tests/integration/consumer_producer/mod.rs
+++ b/tests/integration/consumer_producer/mod.rs
@@ -1,9 +1,12 @@
 pub use super::*;
+
+use std::collections::HashSet;
+use std::time::Duration;
+
 use kafka::producer::{Producer, RequiredAcks};
 use kafka;
-use kafka::client::FetchOffset;
+use kafka::client::{FetchOffset, FetchGroupOffset, PartitionOffset};
 use kafka::consumer::Consumer;
-use std::time::Duration;
 
 pub fn test_producer() -> Producer {
     Producer::from_hosts(vec![LOCAL_KAFKA_BOOTSTRAP_HOST.to_owned()])
@@ -13,36 +16,63 @@ pub fn test_producer() -> Producer {
         .unwrap()
 }
 
+/// This is to avoid copy/pasting the consumer's config, whether
+/// the consumer is built using `from_hosts` or `from_client`.
+///
+/// TODO: This can go away if we don't use the builder pattern.
+macro_rules! test_consumer_config {
+    ( $x:expr ) => {
+        $x
+            .with_topic_partitions(TEST_TOPIC_NAME.to_owned(), &TEST_TOPIC_PARTITIONS)
+            .with_group(TEST_GROUP_NAME.to_owned())
+            .with_fallback_offset(kafka::consumer::FetchOffset::Latest)
+            .with_offset_storage(kafka::consumer::GroupOffsetStorage::Kafka)
+    };
+}
+
 /// Return a Consumer builder with some defaults
 pub fn test_consumer_builder() -> kafka::consumer::Builder {
-    Consumer::from_hosts(vec![LOCAL_KAFKA_BOOTSTRAP_HOST.to_owned()])
-        .with_topic_partitions(TEST_TOPIC_NAME.to_owned(), &TEST_TOPIC_PARTITIONS)
-        .with_group(TEST_GROUP_NAME.to_owned())
-        .with_fallback_offset(kafka::consumer::FetchOffset::Latest)
-        .with_offset_storage(kafka::consumer::GroupOffsetStorage::Kafka)
+    test_consumer_config!(Consumer::from_hosts(vec![LOCAL_KAFKA_BOOTSTRAP_HOST.to_owned()]))
+}
+
+pub fn test_consumer() -> Consumer {
+    test_consumer_with_client(new_ready_kafka_client())
 }
 
 /// Return a ready Kafka consumer with all default settings
-pub fn test_consumer() -> Consumer {
-    let mut consumer = test_consumer_builder().create().unwrap();
+pub fn test_consumer_with_client(mut client: KafkaClient) -> Consumer {
     let topics = [TEST_TOPIC_NAME, TEST_TOPIC_NAME_2];
 
     // Fetch the latest offsets and commit those so that this consumer
     // is always at the latest offset before being used.
-    {
-        let client = consumer.client_mut();
-        let latest_offsets = client.fetch_offsets(&topics, FetchOffset::Latest).unwrap();
+    let latest_offsets = client.fetch_offsets(&topics, FetchOffset::Latest).unwrap();
 
-        for (topic, partition_offsets) in latest_offsets {
-            for po in partition_offsets {
-                client
-                    .commit_offset(TEST_GROUP_NAME, &topic, po.partition, po.offset)
-                    .unwrap();
+    debug!("latest_offsets: {:?}", latest_offsets);
+
+    for (topic, partition_offsets) in latest_offsets {
+        for po in partition_offsets {
+            if po.offset == -1 {
+                continue;
             }
+
+            client
+                .commit_offset(TEST_GROUP_NAME, &topic, po.partition, po.offset)
+                .unwrap();
         }
     }
 
-    consumer
+    client.load_metadata_all().unwrap();
+    let partition_offsets: HashSet<PartitionOffset> = client
+        .fetch_group_topic_offsets(TEST_GROUP_NAME, TEST_TOPIC_NAME)
+        .unwrap()
+        .into_iter()
+        .collect();
+
+    debug!("partition_offsets: {:?}", partition_offsets);
+
+    test_consumer_config!(Consumer::from_client(client))
+        .create()
+        .unwrap()
 }
 
 mod producer;

--- a/tests/integration/consumer_producer/mod.rs
+++ b/tests/integration/consumer_producer/mod.rs
@@ -1,13 +1,14 @@
 pub use super::*;
 use kafka::producer::{Producer, RequiredAcks};
 use kafka;
+use kafka::client::FetchOffset;
 use kafka::consumer::Consumer;
 use std::time::Duration;
 
 pub fn test_producer() -> Producer {
     Producer::from_hosts(vec![LOCAL_KAFKA_BOOTSTRAP_HOST.to_owned()])
         .with_ack_timeout(Duration::from_secs(1))
-        .with_required_acks(RequiredAcks::One)
+        .with_required_acks(RequiredAcks::All)
         .create()
         .unwrap()
 }
@@ -23,7 +24,25 @@ pub fn test_consumer_builder() -> kafka::consumer::Builder {
 
 /// Return a ready Kafka consumer with all default settings
 pub fn test_consumer() -> Consumer {
-    test_consumer_builder().create().unwrap()
+    let mut consumer = test_consumer_builder().create().unwrap();
+    let topics = [TEST_TOPIC_NAME, TEST_TOPIC_NAME_2];
+
+    // Fetch the latest offsets and commit those so that this consumer
+    // is always at the latest offset before being used.
+    {
+        let client = consumer.client_mut();
+        let latest_offsets = client.fetch_offsets(&topics, FetchOffset::Latest).unwrap();
+
+        for (topic, partition_offsets) in latest_offsets {
+            for po in partition_offsets {
+                client
+                    .commit_offset(TEST_GROUP_NAME, &topic, po.partition, po.offset)
+                    .unwrap();
+            }
+        }
+    }
+
+    consumer
 }
 
 mod producer;

--- a/tests/run-all-tests
+++ b/tests/run-all-tests
@@ -53,7 +53,7 @@ teardown() {
 
 # need to run tests serially to avoid the tests stepping on each others' toes
 export RUST_TEST_THREADS=1
-DEFAULT_VERS='0.8.2.2 0.9.0.1 latest'
+DEFAULT_VERS='0.8.2.2 0.9.0.1 0.10.2.1 latest'
 vers=$@
 
 if [[ -z "$vers" ]]; then

--- a/tests/test_kafka.rs
+++ b/tests/test_kafka.rs
@@ -2,8 +2,18 @@
 extern crate kafka;
 
 #[cfg(feature = "integration_tests")]
+extern crate rand;
+
+#[cfg(feature = "integration_tests")]
+#[macro_use]
+extern crate log;
+
+#[cfg(feature = "integration_tests")]
+extern crate env_logger;
+
+#[cfg(feature = "integration_tests")]
 mod integration {
-    use kafka::client::KafkaClient;
+    use kafka::client::{KafkaClient, GroupOffsetStorage};
 
     mod client;
     mod consumer_producer;
@@ -18,6 +28,7 @@ mod integration {
     pub(crate) fn new_ready_kafka_client() -> KafkaClient {
         let hosts = vec![LOCAL_KAFKA_BOOTSTRAP_HOST.to_owned()];
         let mut client = KafkaClient::new(hosts);
+        client.set_group_offset_storage(GroupOffsetStorage::Kafka);
         client.load_metadata_all().unwrap();
         client
     }


### PR DESCRIPTION
When the Kafka Consumer commits offsets, the offset that it commits should be the offset of the next message that it will read.

* https://kafka.apache.org/documentation.html#theconsumer
* https://kafka.apache.org/090/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html

However, when the `Consumer` was choosing which offset to send in the offset commit request inside `Consumer::commit_consumed`, it chose the offset of the most recently "consumed" message, which is *not* the next offset that the consumer should read.

This fixes the off-by-one error, and adds a test to make sure it works.