### PR TITLE
Exposing compression enum as public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,6 @@ pub mod producer;
 mod utils;
 mod codecs;
 mod protocol;
-mod compression;
+pub mod compression;
 
 pub use self::error::{Error, Result};


### PR DESCRIPTION
This allows users to define the compression algorithm, for example, using KafkaClient::set_compression.

Let me know if there's some other way to do this (I am pretty new to Rust).